### PR TITLE
Implement `with` for read access to MDC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,13 @@ pub fn iter<F>(mut f: F)
     })
 }
 
+/// Invokes the provided closure with read-only access to all entries in the MDC.
+pub fn with<F, T>(f: F) -> T
+    where F: FnOnce(&HashMap<String, String>) -> T
+{
+    MDC.with(|m| f(&*m.borrow()))
+}
+
 /// A guard object which restores an MDC entry when dropped.
 pub struct InsertGuard {
     key: Option<String>,


### PR DESCRIPTION
Addresses #1.

It would be fairly straightforward to implement a symmetric `with_mut` function as well:

```rust
pub fn with_mut<F, T>(f: F) -> T
    where F: FnOnce(&mut HashMap<String, String>) -> T
{
    MDC.with(|m| f(&mut *m.borrow_mut()))
}
```

I don't have an immediate use-case for this, though. I can add this in if you'd like, although it feels a little *too* powerful for the purposes of MDC.
